### PR TITLE
Add include for raw_string_ostream.

### DIFF
--- a/src/IRCanonicalizer.cpp
+++ b/src/IRCanonicalizer.cpp
@@ -8,6 +8,7 @@
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <vector>
 


### PR DESCRIPTION
Add the header needed for `raw_string_ostream` class which was preventing this building against LLVM 10.